### PR TITLE
Adds case for single instance EB deployments

### DIFF
--- a/configuration-files/aws-provided/security-configuration/https-redirect/python/https-redirect-python.config
+++ b/configuration-files/aws-provided/security-configuration/https-redirect/python/https-redirect-python.config
@@ -30,10 +30,10 @@ files:
     group: root
     content: |
       RewriteEngine On
-      RewriteCond %{HTTP:X-Forwarded-Proto} !https
-      RewriteCond %{HTTP_USER_AGENT} !ELB-HealthChecker
-      RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI}
-
+      <If "-n '%{HTTP:X-Forwarded-Proto}' && %{HTTP:X-Forwarded-Proto} != 'https' && %{HTTP_USER_AGENT} != 'ELB-HealthChecker'">
+          RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI}
+      </If>
+  
   "/opt/elasticbeanstalk/hooks/config.py":
     mode: 000644
     owner: root


### PR DESCRIPTION
The previous configuration would break on single instance EB deployments since, without a load balancer, x-forwarded-proto would not be set leading to an infinite redirect loop.  This adds a check for whether or not x-forwarded-proto is set, and only redirects if it is.  One conceivable use case for this is an EB application that has a single server (no load balancer or https) deployment for testing or demos and a multi-server deployment for production.