### PR TITLE
Update SSHSourceRestriction example

### DIFF
--- a/configuration-files/aws-provided/security-configuration/ssh-sourcerestriction.config
+++ b/configuration-files/aws-provided/security-configuration/ssh-sourcerestriction.config
@@ -17,9 +17,9 @@
 #### avoid opening port 22 to the entire world by restricting SSH connections to those coming from
 #### another security group in AWS, i.e. one that you attach to a bastion host that you only launch
 #### when you need to connect to an instance in the environment.
-#### Replace "my-security-group" with the name of a security group in the same VPC.
+#### Replace "sg-1234abcd" with the id of a security group in the same VPC.
 ###################################################################################################
 
 option_settings:
   aws:autoscaling:launchconfiguration:
-    SSHSourceRestriction: tcp, 22, 22, my-security-group
+    SSHSourceRestriction: tcp, 22, 22, sg-1234abcd


### PR DESCRIPTION
SSHSourceRestriction requires a Security Group ID e.g sg-1234abcd not a Security Group Name. It will error out if you provide it with a name and indicate that it's after something like sg-...

