### PR TITLE
fixing https-instancecert-nodejs.config configuration file

### DIFF
--- a/configuration-files/aws-provided/security-configuration/https-instancecert/https-instancecert-nodejs.config
+++ b/configuration-files/aws-provided/security-configuration/https-instancecert/https-instancecert-nodejs.config
@@ -57,7 +57,6 @@ files:
           ssl_session_timeout  5m;
           
           ssl_protocols  TLSv1 TLSv1.1 TLSv1.2;
-          ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
           ssl_prefer_server_ciphers   on;
           
           location / {
@@ -84,10 +83,6 @@ files:
     group: root
     authentication: "S3Auth"
     source: { "Ref" : "privatekey" }
-
-container_commands:
-  01restart_nginx:
-    command: "service nginx restart"
 
 Resources:
   # Use instance profile to authenticate to S3 bucket that contains the private key


### PR DESCRIPTION
After testing the .ebextensions configuration file , I have detected two major issues. They are:

1) In line 60, the 'ssl_ciphers' option breaks the communication between the Load Balancer and the instance. Removing this line solves the issue. Please find the code snip below:
--- snip ---
ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
--- snip ---

2) From line 88 to line 90, there is a container_commands key to restart Nginx proxy. The ebextensions fails with the following error message:
[SUPRESSED] INFO [SUPRESSED] - [Application update SUPPRESED@SUPPRESED/AppDeployStage0/EbExtensionPostBuild/Infra-EmbeddedPostBuild/postbuild_0_nodejs_test/Command 01restart_nginx] : Activity execution failed, because: /bin/sh: service: command not found
(ElasticBeanstalk::ExternalInvocationError)

This error message can be found in /var/log/eb-activity.log on the EC2 instance.

Removing this solves the issue since inside the appdeploy/enact folder Elastic Beanstalk has a hook script that restart the proxy layer.

Please find the code snip below:
--- snip ---
container_commands:
01restart_nginx:
command: "service nginx restart"
--- snip ---