### PR TITLE
Fixed mounting issue

### DIFF
--- a/configuration-files/aws-provided/instance-configuration/storage-efs-mountfilesystem.config
+++ b/configuration-files/aws-provided/instance-configuration/storage-efs-mountfilesystem.config
@@ -28,6 +28,14 @@
 ####    http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-dns.html
 ###################################################################################################
 
+container_commands:
+  1chown:
+    command: "chown webapp:webapp /efs"
+  2create:
+    command: "sudo -u webapp mkdir -p wp-content/uploads"
+  3link:
+    command: "sudo -u webapp ln -s /efs wp-content/uploads"
+
 option_settings:
   aws:elasticbeanstalk:application:environment:
     FILE_SYSTEM_ID: '`{"Ref" : "FileSystem"}`'


### PR DESCRIPTION
As the script throws the error: unable  to  create the directory /efs while setting up WordPress through cloud formation