### PR TITLE
Update rds-ssl-java.config

### DIFF
--- a/configuration-files/aws-provided/security-configuration/rds-ssl-java.config
+++ b/configuration-files/aws-provided/security-configuration/rds-ssl-java.config
@@ -33,9 +33,6 @@ option_settings:
 ##############################################
 #### Do not modify values below this line ####
 ##############################################
-
-packages:
-  yum:
     
 commands:
   01_install:
@@ -47,7 +44,7 @@ files:
       content : |
         #!/bin/bash
 
-        APP_REGION=$(/opt/elasticbeanstalk/bin/get-config environment APP_REGION)
+        APP_REGION=$(/opt/elasticbeanstalk/bin/get-config environment -k APP_REGION)
         if [ -z "$APP_REGION" ]; then
                 echo "Could not determine proper environment region!"
                 exit 1


### PR DESCRIPTION
I was unable to get elastic beanstalk to properly deploy until the following changes were made. This got it working for me on a java 8 environment. It was a quick hack so I may not understand the full implication of what I did.

* Need a -k for APP_REGION to function properly it seems
* Got error on deployment along the lines of Can not have a `'null'` value under `packages: yum:` so removed the code and got it to work.