### PR TITLE
Using Amazon Time Sync Service host IP address to synchronize time.

### DIFF
--- a/configuration-files/aws-provided/instance-configuration/timezone-linux.config
+++ b/configuration-files/aws-provided/instance-configuration/timezone-linux.config
@@ -44,7 +44,7 @@ files:
       echo 'ZONE="'$NEWTIMEZONE'"' > /etc/sysconfig/clock
       echo 'UTC=true' >> /etc/sysconfig/clock
       ln -f -s /usr/share/zoneinfo/$NEWTIMEZONE /etc/localtime
-      ntpdate -u pool.ntp.org
+      ntpdate -u 169.254.169.123
 
 commands:
   00-custom-timezone:


### PR DESCRIPTION
Proposing this change based on AWS Docs at https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-time.html. This documentation states: 

The Amazon Time Sync Service is available through NTP at the 169.254.169.123 IP address for any instance running in a VPC. Your instance does not require access to the internet, and you do not have to configure your security group rules or your network ACL rules to allow access. 