### PR TITLE
Set header connection upgrade for wss support

### DIFF
--- a/configuration-files/aws-provided/security-configuration/https-instancecert/https-instancecert-nodejs.config
+++ b/configuration-files/aws-provided/security-configuration/https-instancecert/https-instancecert-nodejs.config
@@ -61,7 +61,7 @@ files:
           
           location / {
               proxy_pass  http://nodejs;
-              proxy_set_header   Connection "";
+              proxy_set_header   Connection "upgrade";
               proxy_http_version 1.1;
               proxy_set_header        Host            $host;
               proxy_set_header        X-Real-IP       $remote_addr;


### PR DESCRIPTION
Use secure websockets with single instance elastic beanstalk.
Related to bug #80 which was closed without resolution.