### PR TITLE
Update https-instancecert-ruby-puma.config

### DIFF
--- a/configuration-files/aws-provided/security-configuration/https-instancecert/https-instancecert-ruby-puma.config
+++ b/configuration-files/aws-provided/security-configuration/https-instancecert/https-instancecert-ruby-puma.config
@@ -63,16 +63,20 @@ files:
               proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
           }
 
-          location /assets {
-            alias /var/app/current/public/assets;
+          # Location has a final backslash to avoid matching valid Rails routes that may start
+          # with assets*, for example a controller assets_pickers_controller
+          location /assets/ {
+            alias /var/app/current/public/assets/;
             gzip_static on;
             gzip on;
             expires max;
             add_header Cache-Control public;
           }
 
-          location /public {
-            alias /var/app/current/public;
+          # Location has a final backslash to avoid matching valid Rails routes that may start
+          # with public*, for example a controller public_profiles_controller
+          location /public/ {
+            alias /var/app/current/public/;
             gzip_static on;
             gzip on;
             expires max;


### PR DESCRIPTION
Without final backslashes on the location directives, valid Rails routes may fail with an NGINX 404 not found error.

For example, a valid controller name `public_profiles_controller` could have a route `/public_profiles/123`. With a location directive `location /public`, this Rails route would be matched, preventing Puma from processing the request.