### PR TITLE
Fixed adding-writepermission-iisfolder.config and aws-inspector-install.config files

### DIFF
--- a/configuration-files/aws-provided/environment-configuration/README.md
+++ b/configuration-files/aws-provided/environment-configuration/README.md
@@ -12,3 +12,9 @@ By default, worker environments scale based on network throughput. Use this conf
 
 ### vpc-custom-loadbalanced.config
 Use this configuration file to tell Elastic Beanstalk to create your instances and load balancer in a custom VPC that you created, instead of in the default VPC.
+
+### loadbalancer-clb-workertier.config
+Use this example when you want to enables an internal classic load balancer for a worker-tier environment. Update the Availability Zones details before applying this configuration file in your environment. Test this configuration file in your test environment before applying to production.
+
+### loadbalancer-cross-zone.config
+This configuration file can help in enabling Cross Zone Balancing on a Classic Load Balance. Other configuration options are listed here: https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html#command-options-general-elbloadbalancer

--- a/configuration-files/aws-provided/environment-configuration/loadbalancer-clb-workertier.config
+++ b/configuration-files/aws-provided/environment-configuration/loadbalancer-clb-workertier.config
@@ -1,0 +1,50 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+####     http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### Use this example when you want to enables an internal classic load balancer for a worker-tier environment
+#### Update the AvailabilityZones details before applying this configuration file in your environment
+#### Test this configuration file in your test environment before applying to production
+###################################################################################################
+
+Resources:
+  AWSEBLoadBalancer:
+    Type: 'AWS::ElasticLoadBalancing::LoadBalancer'
+    Properties:
+      AvailabilityZones:
+        - YOUR_SUBNETS
+        - YOUR_SUBNETS
+        - YOUR_SUBNETS
+      ConnectionDrainingPolicy:
+        Enabled: true
+        Timeout: 20
+      CrossZone: true
+      HealthCheck:
+        HealthyThreshold: '3'
+        Interval: '10'
+        Target:
+          'Fn::Join':
+            - ''
+            - - HTTP
+              - ':'
+              - 80
+              - '/'
+        Timeout: '5'
+        UnhealthyThreshold: '5'
+      SecurityGroups:
+        - Ref: AWSEBSecurityGroup
+      Scheme: internal
+      Listeners:
+        - InstancePort: 80
+          LoadBalancerPort: '80'
+          Protocol: HTTP

--- a/configuration-files/aws-provided/environment-configuration/loadbalancer-cross-zone.config
+++ b/configuration-files/aws-provided/environment-configuration/loadbalancer-cross-zone.config
@@ -1,0 +1,23 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+####     http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file can help in enabling Cross Zone Balancing on a Classic Load Balancer
+#### Other configuration options are listed here:
+#### https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html#command-options-general-elbloadbalancer
+###################################################################################################
+
+option_settings:
+    - namespace: aws:elb:loadbalancer
+      option_name: CrossZone
+      value: true

--- a/configuration-files/aws-provided/instance-configuration/README.md
+++ b/configuration-files/aws-provided/instance-configuration/README.md
@@ -3,8 +3,29 @@ Configure the proxy server that runs in front of your application to allow webso
 If you're using a Classic Load Balancer, you need to enable TCP listeners. See:
 http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.managing.elb.html
 
+### add-ebs-volume.config
+This configuration file add a new volume to the instance, create filesystem and mount it.
+
+### add-secondary-network-interface.config
+This configuration file adds a secondary NetworkInterface to the EC2 instance. The SubnetId for the secondary interface has to be in the same Availability Zone as the instance.
+
+### amazon-inspector-install.config
+This configuration file installs Amazon Inspector Agents on the instance launched under Elastic Beanstalk.
+
+### apache-mpm_prefork.config
+This configuration file increases the number of MPM Prefork daemons. Its Useful on larger instance types that run out of these daemons well before memory or CPU exhaustion.
+
+### awslogs-change-frequency.config
+This configuration file modifies logrotate frequency to 5 minutes and upload to S3.
+
+### change-nginx-max-body-size.config
+This configuration file client_max_body_size in nginx within a Java environment by adding a hook.
+
 ### cron-leaderonly-linux.config
-Run a cron job on only one Linux instance in the environment
+Run a cron job on only one Linux instance in the environment.
+
+### cron-linux.config
+This configuration file shows an example of running a cron job on all linux instances in the environment.
 
 ### env-regionname.config
 Configure Elastic Beanstalk to pass your environment's region to your application with an environment variable.
@@ -12,11 +33,26 @@ Configure Elastic Beanstalk to pass your environment's region to your applicatio
 ### files-downloadfromS3.config
 Use the `files` key to download a file from a bucket in Amazon S3 to the instances in your environment, providing the instance profile role to use for authorization. Use this mechanism to securely provide your application with secrets that you can't include in your source code, such as private keys and database passwords.
 
+### install-newrelic-agent.config
+This configuration file install the infrastructure agent on the instance launched under Elastic Beanstalk. Please find the latest information/config files under new relic public documentation: https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-agent-aws-elastic-beanstalk
+
+### install-nodejs.config
+This configuration file installs nodejs to a non-NodeJs solution stack.
+
+### java-increase-file-descriptors.config
+Increase file descriptors for Java Tomcat environment.
+
 ### logs-streamtocloudwatch-linux.config
 Configure Cloudwatch log agent to stream logs to Cloudwatch
 
 ### logs-uploadonterminate-linux.config
 Publish logs to S3 on termination of a linux instance.
+
+### network-mtu-jumboframe.config
+This configuration file Changes MTU for Jumbo-Frame enabled instances e.g->C3.large
+
+### nodejs-increase-file-descriptors.config
+Increase available file descriptors to Node.js.
 
 ### package-oracle-jdk.config
 Install Oracle JDK and set as default
@@ -33,6 +69,11 @@ Mount an Amazon EFS file system to a local path on the instances in your environ
 
 ### storage-imagevolume-docker.config
 Configure the volume used by the instances in your Docker environment.
+
+### t2unlimited-instance.config
+This configuration file will allow T2 Unlimited with Elastic Beanstalk for Linux based Environments. Since it is not directly possible to use T2 Unlimited instances with Elastic Beanstalk as of now, the below provided ebextensions config file lets you use T2 instances with Surplus credits.
+Note: Since the container_command "set-t2-unlimited" makes an api call "modify-instance-credit-specification", the instance profile associated with the Beanstalk environment's instance must have necessary
+permissions to make the api call (ec2:ModifyInstanceCreditSpecification).
 
 ### timezone-linux.config
 Configure the timezone on each instance.

--- a/configuration-files/aws-provided/instance-configuration/add-ebs-volume.config
+++ b/configuration-files/aws-provided/instance-configuration/add-ebs-volume.config
@@ -1,0 +1,29 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+#### http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file add a new volume to the instance, create filesystem and mount it
+###################################################################################################
+
+commands:
+  01mkfs:
+    command: "mkfs -t ext3 /dev/sdh"
+  02mkdir:
+    command: "mkdir /media/volume1"
+  03mount:
+    command: "mount /dev/sdh /media/volume1"
+
+option_settings:
+  - namespace: aws:autoscaling:launchconfiguration
+    option_name: BlockDeviceMappings
+    value: /dev/sdh=:100

--- a/configuration-files/aws-provided/instance-configuration/add-secondary-network-interface.config
+++ b/configuration-files/aws-provided/instance-configuration/add-secondary-network-interface.config
@@ -1,0 +1,85 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+#### http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file adds a secondary NetworkInterface to the EC2 instance. The SubnetId for the
+#### secondary interface has to be in the same Availability Zone as the instance.
+###################################################################################################
+
+Resources:
+  MyNetworkInterface:
+    Type: 'AWS::EC2::NetworkInterface'
+    Properties:
+      Tags:
+        - Key: MyInterface
+          Value: Address
+      Description: Secondary interface.
+      SourceDestCheck: 'false'
+      SubnetId: subnet-XXXXXXXX     #Subnet for the second interface has to be in the same "AZ" as the instance.
+files:
+  /etc/elasticbeanstalk/environmentMetadata.sh:
+    mode: '000755'
+    owner: ec2-user
+    group: ec2-user
+    content:
+      'Fn::Join':
+        - ''
+        - - "# /etc/elasticbeanstalk/environmentMetadata.sh"
+          -  "\n"
+          - "export eb_environmentname='"
+          - Ref: AWSEBEnvironmentName
+          - "\n"
+          - "export eb_instancetype='"
+          - 'Fn::GetOptionSetting':
+              Namespace: 'aws:autoscaling:launchconfiguration'
+              OptionName: InstanceType
+          - "\n"
+          - "export eb_region='"
+          - Ref: 'AWS::Region'
+          - "\n"
+          - export eb_instanceIP='$(curl -s 169.254.169.254/latest/meta-data/local-ipv4)
+          - "\n"
+          - export eb_InstanceID=$(curl -s 169.254.169.254/latest/meta-data/instance-id)
+          - "\n"
+          - export eb_NetworkENI=$(aws ec2 describe-network-interfaces
+          - ' --region '
+          - Ref: 'AWS::Region'
+          - ' --filter Name=status,Values=available'
+          - " --query 'NetworkInterfaces[?PrivateIpAddress==`"
+          - 'Fn::GetAtt':
+              - MyNetworkInterface
+              - PrimaryPrivateIpAddress
+          - "`].NetworkInterfaceId' --output text)"
+          - "\n"
+
+  /tmp/env_variables.sh:
+    mode: '000775'
+    owner: ec2-user
+    group: ec2-user
+    content:
+      'Fn::Join':
+        - ''
+        - - "#!/bin/bash"
+          - "\n"
+          - "# /tmp/env_variables.sh"
+          - "\n"
+          - "source /etc/elasticbeanstalk/environmentMetadata.sh"
+          - "\n"
+          - "aws ec2 attach-network-interface --network-interface-id $eb_NetworkENI --instance-id $eb_InstanceID --device-index 1"
+          - " --region "
+          - Ref: 'AWS::Region'
+          - "\n"
+
+commands:
+  Environment_Variables:
+    command: /tmp/env_variables.sh

--- a/configuration-files/aws-provided/instance-configuration/amazon-inspector-install.config
+++ b/configuration-files/aws-provided/instance-configuration/amazon-inspector-install.config
@@ -1,0 +1,28 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+#### http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file installs Amazon Inspector Agents on the instance launched under Elastic Beanstalk
+#### https://docs.aws.amazon.com/inspector/latest/userguide/inspector_installing-uninstalling-agents.html
+###################################################################################################
+
+files:
+  "/tmp/install" :
+    mode: "000755"
+    owner: root
+    group: root
+    source: https://inspector-agent.amazonaws.com/linux/latest/install
+commands:
+  install_inspector:
+    command: bash -x install -u false
+    cwd: /tmp/

--- a/configuration-files/aws-provided/instance-configuration/apache-mpm_prefork.config
+++ b/configuration-files/aws-provided/instance-configuration/apache-mpm_prefork.config
@@ -1,0 +1,30 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+#### http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file increases the number of MPM Prefork daemons.
+#### Its Useful on larger instance types that run out of these daemons well before memory or CPU exhaustion
+#### Add this section on the end under MaxRequestWorkers to allow you to verify the change at http://yourenvironmentnamehere.elasticbeanstalk.com/server-info
+#### <Location /server-info>
+#### SetHandler server-info
+#### </Location>
+###################################################################################################
+
+files:
+  "/etc/httpd/conf.d/mpm_prefork.conf":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      ServerLimit 512
+      MaxRequestWorkers 512

--- a/configuration-files/aws-provided/instance-configuration/awslogs-change-frequency.config
+++ b/configuration-files/aws-provided/instance-configuration/awslogs-change-frequency.config
@@ -1,0 +1,63 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+#### http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file modifies logrotate frequency to 5 minutes and upload to S3
+###################################################################################################
+
+files:
+    "/etc/cron.d/cron.logrotate.elasticbeanstalk.httpd.conf":
+        mode: "000644"
+        owner: root
+        group: root
+        content: |
+            SHELL=/bin/sh
+            PATH=/sbin:/bin:/usr/sbin:/usr/bin
+            MAILTO=root
+            HOME=/
+            */5 * * * * root test -x /usr/sbin/logrotate || exit 0 && /usr/sbin/logrotate -f /etc/logrotate.elasticbeanstalk.hourly/logrotate.elasticbeanstalk.httpd.conf
+
+    "/etc/cron.d/cron.logrotate.elasticbeanstalk.webapp.conf":
+        mode: "000644"
+        owner: root
+        group: root
+        content: |
+            SHELL=/bin/sh
+            PATH=/sbin:/bin:/usr/sbin:/usr/bin
+            MAILTO=root
+            HOME=/
+            */5 * * * * root test -x /usr/sbin/logrotate || exit 0 && /usr/sbin/logrotate -f /etc/logrotate.elasticbeanstalk.hourly/logrotate.elasticbeanstalk.webapp.conf
+
+    "/etc/cron.d/publishlogs":
+        mode: "000644"
+        owner: root
+        group: root
+        content: |
+            SHELL=/bin/bash
+            PATH=/sbin:/bin:/usr/sbin:/usr/bin
+            MAILTO=""
+            HOME=/
+            #This will run every 5 minutes starting at minute 5 of each hour
+            1-59/5 * * * * root publishLogs.py --de-dupe --conf-path '/opt/elasticbeanstalk/tasks/publishlogs.d/*' --location-prefix resources/environments/logs/publish/ --num-concurrent 2
+            #This will run every 20 minutes starting at minute 6 of each hour
+            6-59/20 * * * * root clearStaleLogPublishingRecords.py
+
+# Commands are executed after file creation
+commands:
+    # Ensure that automatically created .bak files are removed from cron.d
+    remove_.bak_crons:
+        command: rm -f *.bak
+        cwd: /etc/cron.d
+    remove_rotate_crons:
+        command: rm -f cron.logrotate.elasticbeanstalk.httpd.conf cron.logrotate.elasticbeanstalk.webapp.conf
+        cwd: /etc/cron.hourly

--- a/configuration-files/aws-provided/instance-configuration/change-nginx-max-body-size.config
+++ b/configuration-files/aws-provided/instance-configuration/change-nginx-max-body-size.config
@@ -1,0 +1,26 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+#### http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file client_max_body_size in nginx within a Java environment by adding a hook
+###################################################################################################
+
+files:
+  "/opt/elasticbeanstalk/hooks/appdeploy/enact/12_add_nginx_configuration.sh":
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      #!/usr/bin/env bash
+      /bin/echo "client_max_body_size 50M;" > /etc/nginx/conf.d/proxy.conf
+      /sbin/service nginx reload

--- a/configuration-files/aws-provided/instance-configuration/install-newrelic-agent.config
+++ b/configuration-files/aws-provided/instance-configuration/install-newrelic-agent.config
@@ -1,0 +1,42 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+#### http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### The following config uses a set of commands to download and install new relic agent and monitors
+#### You should update the MSI download path and your NR_LICENSE_KEY before applying this config
+#### in your environment.
+####
+#### Please find the latest information/configuration files under new relic public documentation
+#### https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-agent-aws-elastic-beanstalk
+###################################################################################################
+
+files:
+  "/etc/newrelic-infra.yml" :
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      license_key: YOUR_LICENSE_KEY
+
+commands:
+# Create the agent’s yum repository
+  "01-agent-repository":
+    command: sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/el/6/x86_64/newrelic-infra.repo
+
+# Update your yum cache
+  "02-update-yum-cache":
+    command: yum -q makecache -y --disablerepo='*' --enablerepo='newrelic-infra'
+
+# Run the installation script
+  "03-run-installation-script":
+    command: sudo yum install newrelic-infra -y

--- a/configuration-files/aws-provided/instance-configuration/install-nodejs.config
+++ b/configuration-files/aws-provided/instance-configuration/install-nodejs.config
@@ -1,0 +1,49 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+#### http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file installs nodejs to a non-NodeJs solution stack. Uncomment the line that
+#### relates to the specific major node version
+###################################################################################################
+
+files:
+  "/tmp/prep_node_installation.sh" :
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      #! /bin/bash
+      # Uncomment the line that relates to the specific major node version you want installed
+
+      #  The URL without a major version branch below will result in a node 0.10 installation
+      #  curl --silent --location https://rpm.nodesource.com/setup | bash -
+      #
+      #  curl --silent --location https://rpm.nodesource.com/setup_4.x | bash -
+      #  curl --silent --location https://rpm.nodesource.com/setup_6.x | bash -
+
+  "/tmp/install_node.sh" :
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      #! /bin/bash
+      yum -y install nodejs
+
+commands:
+  00_prep_for_node_install:
+    command: "sh /tmp/prep_node_installation.sh"
+    ignoreErrors: false
+
+  10_install_node:
+    command: "sh /tmp/install_node.sh"
+    ignoreErrors: false

--- a/configuration-files/aws-provided/instance-configuration/java-increase-file-descriptors.config
+++ b/configuration-files/aws-provided/instance-configuration/java-increase-file-descriptors.config
@@ -1,0 +1,34 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+#### http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### Increase file descriptors for Java Tomcat environment
+#### Note: Replace 20000 by the desired number of file descriptors.
+#### This will increase the number of file descriptors available to all users.
+###################################################################################################
+
+files:
+  "/etc/security/limits.d/openfiles.conf":
+    mode: "00644"
+    owner: "root"
+    group: "root"
+    content: |
+      * soft nofile 20000
+      * hard nofile 20000
+
+container_commands:
+  01_increase_ulimit:
+    command: "ulimit -HSn 20000; monit restart httpd tomcat; exit 0"
+  02_cleanup:
+    command: "rm /etc/security/limits.d/openfiles.conf.bak"
+    ignoreErrors: true

--- a/configuration-files/aws-provided/instance-configuration/network-mtu-jumboframe.config
+++ b/configuration-files/aws-provided/instance-configuration/network-mtu-jumboframe.config
@@ -1,0 +1,47 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+#### http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file Changes MTU for Jumbo-Frame enabled instances e.g->C3.large
+#### In order to get a 1500 MTU you need to also tell dhclient to ignore the interface-mtu option
+#### received from the DHCP server
+###################################################################################################
+
+files:
+  "/etc/dhcp/dhclient.conf":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+     timeout 300;
+     request subnet-mask,  broadcast-address, time-offset, routers, domain-name, domain-search, domain-name-servers, host-name, nis-domain, nis-servers, ntp-servers;
+
+  "/etc/sysconfig/network-scripts/ifcfg-eth0":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      DEVICE=eth0
+      BOOTPROTO=dhcp
+      ONBOOT=yes
+      MTU=1500
+      TYPE=Ethernet
+      USERCTL=yes
+      PEERDNS=yes
+      IPV6INIT=no
+      PERSISTENT_DHCLIENT=yes
+
+commands:
+  restart_network:
+    command: sudo /sbin/service network restart
+    ignoreErrors: true

--- a/configuration-files/aws-provided/instance-configuration/nodejs-increase-file-descriptors.config
+++ b/configuration-files/aws-provided/instance-configuration/nodejs-increase-file-descriptors.config
@@ -1,0 +1,33 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+#### http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### Increase available file descriptors to Node.js
+###################################################################################################
+
+
+files:
+    "/etc/security/limits.d/node.conf":
+        mode: "000644"
+        owner: root
+        group: root
+        content: |
+            nodejs	hard	nofile	8192
+            nodejs	soft	nofile	8192
+
+container_commands:
+    01_restart_node:
+        command: "/sbin/restart nodejs"
+    02_cleanup:
+        command: "rm /etc/security/limits.d/node.conf.bak"
+        ignoreErrors: true

--- a/configuration-files/aws-provided/instance-configuration/t2unlimited-instance.config
+++ b/configuration-files/aws-provided/instance-configuration/t2unlimited-instance.config
@@ -1,0 +1,41 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+#### http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### T2 Unlimited with Elastic Beanstalk for Linux based Environments
+#### Since it is not directly possible to use T2 Unlimited instances with Elastic Beanstalk as of now,
+#### the below provided ebextensions config file lets you use T2 instances with Surplus credits.
+####
+#### Note: Since the container_command "set-t2-unlimited" makes an api call "modify-instance-credit-specification",
+#### the instance profile associated with the Beanstalk environment's instance must have necessary
+#### permissions to make the api call (ec2:ModifyInstanceCreditSpecification).
+###################################################################################################
+
+files:
+  "/tmp/t2-test.sh":
+      mode: "000755"
+      content : |
+        #!/bin/bash
+        instanceType=$(curl -s http://169.254.169.254/latest/meta-data/instance-type)
+        if echo "$instanceType" | grep -qe 't2.*'
+        then
+          exit 0
+        else
+          exit 1
+        fi
+
+container_commands:
+  set-t2-unlimited:
+    command: |
+      aws ec2 modify-instance-credit-specification --region $(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/[a-z]$//') --instance-credit-specification '[{"InstanceId": "'"$(curl -s http://169.254.169.254/latest/meta-data/instance-id)"'","CpuCredits": "unlimited"}]'
+    test: "[ /tmp/t2-test.sh ]"

--- a/configuration-files/aws-provided/instance-configuration/websockets/dotnet/windows-websocket.config
+++ b/configuration-files/aws-provided/instance-configuration/websockets/dotnet/windows-websocket.config
@@ -1,0 +1,24 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+####     http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file will enable windows features 'Web-WebSockets' on the instance launched
+#### under Elastic Beanstalk, also uses appcmd.exe command to enable webSocket on "Default Web Site".
+###################################################################################################
+
+
+commands:
+  InstallWebsocket:
+    command: powershell.exe Install-WindowsFeature -name Web-WebSockets
+  EnableWebsocket:
+    command: 'C:\windows\system32\inetsrv\appcmd.exe set config "Default Web Site" -section:system.webServer/webSocket /enabled:"True" /receiveBufferLimit:"4194304" /pingInterval:"00:00:10"  /commit:apphost'

--- a/configuration-files/aws-provided/instance-configuration/windows-configuration/README.md
+++ b/configuration-files/aws-provided/instance-configuration/windows-configuration/README.md
@@ -1,0 +1,31 @@
+### adding-writepermission-iisfolder.config  
+This configuration file uses powershell to add write permission to a custom IIS folder. Its allowing DefaultAppPool to write in custom IIS folder "C:\inetpub\wwwroot\uploads"
+You can change the path as per your use-case or to the path your application is going to write.
+
+### aws-inspector-install.config             
+This configuration file to installs Amazon Inspector Agents on the windows instance launched under Elastic Beanstalk.
+Please find more information here: https://docs.aws.amazon.com/inspector/latest/userguide/inspector_installing-uninstalling-agents.html
+
+### change-iislog-location.config  
+This configuration file uses appcmd.exe to set new IIS log file directory to a custom folder path. You should change the directory path 'X:\\folder\\' to your desired path before applying this configuration.
+
+### elastic-ip-instance.config
+This configuration file can be used to assign EIP on the instance launched under Elastic Beanstalk
+Replace "MYEIPS" values with the list of your EIP Allocation IDs. The solution was tested on solution stack (64bit Windows Server 2016 v1.2.0 running IIS 10.0) and AMI (ami-xxxxxxxx).
+
+### install-newrelic-agent.config
+This configuration file install the infrastructure agent on the instance launched under Elastic Beanstalk. Please find the latest information/config files under new relic public documentation: https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-agent-aws-elastic-beanstalk
+
+### join-domain-ssm.config
+This configuration file uses SSM association to join windows instances launched under Elastic Beanstalk to domain. With the use of IAM Policy, AWS Directory Service (Microsoft AD)
+and SSM, you can join your Elastic Beanstalk IIS Windows Instances to the AWS Directory Service domain. You can look at the our documentation in order to create IAM Policy and SSM document which is not part of this configuration file: https://aws.amazon.com/blogs/security/how-to-configure-your-ec2-instances-to-automatically-join-a-microsoft-active-directory-domain/
+
+### t2unlimited-instance.config  
+This configuration file will allow T2 Unlimited with Elastic Beanstalk for Windows based Environments. Since it is not directly possible to use T2 Unlimited instances with Elastic Beanstalk as of now the provided ebextensions config file lets you use T2 instances with Surplus credits.
+
+### timezone-windows.config  
+This configuration file configures the timezone on each instance in the environment. Its using tzutil command to set timezone on the instance.
+Have a look at the URL https://technet.microsoft.com/en-us/library/cc749073%28v=ws.10%29.aspx for all possible time zone values in this case its done for UTC+1.
+
+### web-http-tracing.config
+This configuration file enables WindowsFeature Web-Http-Tracing on the windows instance launched under Elastic Beanstalk and request tracing will capture traces for requests which resulted in status codes from 400 to 599; by default, the latest 50 error traces will be saved on: %systemdrive%\inetpub\logs\FailedReqLogFiles\. Request Monitor will enable the feature to  monitor currently/hanging requests.

--- a/configuration-files/aws-provided/instance-configuration/windows-configuration/adding-writepermission-iisfolder.config
+++ b/configuration-files/aws-provided/instance-configuration/windows-configuration/adding-writepermission-iisfolder.config
@@ -1,0 +1,40 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+#### http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file uses powershell to add write permission to a custom IIS folder.
+#### Its allowing DefaultAppPool to write in custom IIS folder "C:\inetpub\wwwroot\uploads"
+#### You can change the path as per your use-case or to the path your application wants to write
+###################################################################################################
+
+files:
+  "C:\\scripts\\permissions.ps1":
+    content: |
+      Import-Module WebAdministration
+      $appPoolName='DefaultAppPool'
+      $folderDirectory='C:\inetpub\wwwroot\uploads'
+
+      $appPoolSid = (Get-ItemProperty IIS:\AppPools\$appPoolName).applicationPoolSid
+      $identifier = New-Object System.Security.Principal.SecurityIdentifier $appPoolSid
+      $user = $identifier.Translate([System.Security.Principal.NTAccount])
+
+      $acl = Get-Acl $folderDirectory
+      $acl.SetAccessRuleProtection($True, $False)
+      $rule = New-Object System.Security.AccessControl.FileSystemAccessRule($user,”FullControl”, “ContainerInherit, ObjectInherit”, “None”, “Allow”)
+      $acl.AddAccessRule($rule)
+
+container_commands :
+  set_permission:
+    command: powershell.exe -ExecutionPolicy Bypass -Command "C:\\scripts\\permissions.ps1"
+    ignoreErrors: false
+    waitAfterCompletion: 5

--- a/configuration-files/aws-provided/instance-configuration/windows-configuration/adding-writepermission-iisfolder.config
+++ b/configuration-files/aws-provided/instance-configuration/windows-configuration/adding-writepermission-iisfolder.config
@@ -22,16 +22,31 @@ files:
     content: |
       Import-Module WebAdministration
       $appPoolName='DefaultAppPool'
+
+      # Update your custom IIS folder path here
       $folderDirectory='C:\inetpub\wwwroot\uploads'
 
       $appPoolSid = (Get-ItemProperty IIS:\AppPools\$appPoolName).applicationPoolSid
       $identifier = New-Object System.Security.Principal.SecurityIdentifier $appPoolSid
       $user = $identifier.Translate([System.Security.Principal.NTAccount])
 
+      If(!(test-path $folderDirectory))
+      {
+         New-Item -ItemType Directory -Force -Path $folderDirectory
+      }
       $acl = Get-Acl $folderDirectory
-      $acl.SetAccessRuleProtection($True, $False)
-      $rule = New-Object System.Security.AccessControl.FileSystemAccessRule($user,”FullControl”, “ContainerInherit, ObjectInherit”, “None”, “Allow”)
+
+      # SetAccessRuleProtection (bool isProtected, bool preserveInheritance);
+      # isProtected - true to protect the access rules associated with this ObjectSecurity object from inheritance; false to allow inheritance.
+      # preserveInheritance - true to preserve inherited access rules; false to remove inherited access rules. This parameter is ignored if isProtected is false.
+
+      $acl.SetAccessRuleProtection($False, $True)
+      $rule = New-Object System.Security.AccessControl.FileSystemAccessRule($user,"FullControl", "ContainerInherit, ObjectInherit", "None", "Allow")
       $acl.AddAccessRule($rule)
+      Set-Acl $folderDirectory $acl
+
+      # Print the final ACL in log
+      # Get-Acl $folderDirectory  | Format-List
 
 container_commands :
   set_permission:

--- a/configuration-files/aws-provided/instance-configuration/windows-configuration/aws-inspector-install.config
+++ b/configuration-files/aws-provided/instance-configuration/windows-configuration/aws-inspector-install.config
@@ -1,0 +1,27 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+#### http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file to installs Amazon Inspector Agents on the windows instance launched
+#### under Elastic Beanstalk.
+#### https://docs.aws.amazon.com/inspector/latest/userguide/inspector_installing-uninstalling-agents.html
+###################################################################################################
+
+
+files:
+  "C:\\Temp\\AWSAgentInstall.exe" :
+    source: https://inspector-agent.amazonaws.com/windows/installer/latest/AWSAgentInstall.exe
+commands:
+  install_inspector:
+    command: ""C:\\Temp\\AWSAgentInstall.exe"
+    cwd: "C:\\Temp\\"

--- a/configuration-files/aws-provided/instance-configuration/windows-configuration/aws-inspector-install.config
+++ b/configuration-files/aws-provided/instance-configuration/windows-configuration/aws-inspector-install.config
@@ -19,9 +19,9 @@
 
 
 files:
-  "C:\\Temp\\AWSAgentInstall.exe" :
+  "C:\\Temp\\AWSAgentInstall.exe":
     source: https://inspector-agent.amazonaws.com/windows/installer/latest/AWSAgentInstall.exe
 commands:
   install_inspector:
-    command: ""C:\\Temp\\AWSAgentInstall.exe"
+    command: "C:\\Temp\\AWSAgentInstall.exe /quiet"
     cwd: "C:\\Temp\\"

--- a/configuration-files/aws-provided/instance-configuration/windows-configuration/change-iislog-location.config
+++ b/configuration-files/aws-provided/instance-configuration/windows-configuration/change-iislog-location.config
@@ -1,0 +1,23 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+#### http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file uses appcmd.exe to set new IIS log file directory to a custom folder path
+#### You should change the directory path 'X:\\folder\\' to your desired path before applying this configuration
+###################################################################################################
+
+commands:
+  ChangeLogLocation:
+    command: "%systemroot%\\system32\\inetsrv\\appcmd.exe set config -section:system.applicationHost/sites /siteDefaults.logFile.directory:'X:\\folder\\' /commit:apphost"
+  IISreset:
+    command: "%systemroot%\\system32\\iisreset.exe"

--- a/configuration-files/aws-provided/instance-configuration/windows-configuration/elastic-ip-instance.config
+++ b/configuration-files/aws-provided/instance-configuration/windows-configuration/elastic-ip-instance.config
@@ -1,0 +1,34 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+#### http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file can be used to assign EIP on the instance launched under Elastic Beanstalk
+#### - Replace "MYEIPS" values with the list of your EIP Allocation IDs.
+#### - The solution was tested on solution stack (64bit Windows Server 2016 v1.2.0 running IIS 10.0) and AMI (ami-xxxxxxxxxx).
+###################################################################################################
+
+packages:
+  msi:
+    awscli: https://s3.amazonaws.com/aws-cli/AWSCLI64PY3.msi
+files:
+  "C:\\assigneip.ps1":
+    content: |
+      $env:Path += ";C:\Program Files\Amazon\AWSCLI\bin\"
+      $MYEIPS="eipalloc-xxxxxxxxxxxxxxxxx", "eipalloc-xxxxxxxxxxxxxxxxx", "eipalloc-xxxxxxxxxxxxxxxxx"
+      $IID = (New-Object System.Net.WebClient).DownloadString("http://169.254.169.254/latest/meta-data/instance-id")
+      $AV = (New-Object System.Net.WebClient).DownloadString("http://169.254.169.254/latest/meta-data/placement/availability-zone")
+      $REGION=$AV -replace ".$"
+      foreach ($EIP in $MYEIPS) {aws ec2 associate-address --allocation-id $EIP --instance-id $IID --no-allow-reassociation --region=$REGION}
+container_commands:
+  script:
+    command: powershell.exe -ExecutionPolicy Bypass -File "C:\\assigneip.ps1"

--- a/configuration-files/aws-provided/instance-configuration/windows-configuration/install-newrelic-agent.config
+++ b/configuration-files/aws-provided/instance-configuration/windows-configuration/install-newrelic-agent.config
@@ -1,0 +1,34 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+#### http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file install the infrastructure agent on the instance launched under Elastic Beanstalk.
+#### You should update the MSI download path and your NR_LICENSE_KEY before applying this config
+#### in your environment. Please find the latest information/config files under new relic public
+#### documentation https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-agent-aws-elastic-beanstalk
+###################################################################################################
+
+packages:
+  msi:
+    infrastructure: https://download.newrelic.com/infrastructure_agent/windows/newrelic-infra.msi
+files:
+  "C:\\Program Files\\New Relic\\newrelic-infra\\newrelic-infra.yml":
+    content: |
+      license_key: YOUR_LICENSE_KEY
+commands:
+  01_stop-newrelic-infra:
+    command: net stop newrelic-infra
+    ignoreErrors: true
+  02_start-newrelic-infra:
+    command: net start newrelic-infra
+    ignoreErrors: true

--- a/configuration-files/aws-provided/instance-configuration/windows-configuration/join-domain-ssm.config
+++ b/configuration-files/aws-provided/instance-configuration/windows-configuration/join-domain-ssm.config
@@ -1,0 +1,45 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+#### http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file uses SSM association to join windows instances launched under
+#### Elastic Beanstalk to domain. With the use of IAM Policy, AWS Directory Service (Microsoft AD)
+#### and SSM, you can join your Elastic Beanstalk IIS Windows Instances to the AWS Directory Service domain.
+
+#### You can look at the following documentation in order to create IAM Policy and SSM document which
+#### is not part of this config https://aws.amazon.com/blogs/security/how-to-configure-your-ec2-instances-to-automatically-join-a-microsoft-active-directory-domain/
+###################################################################################################
+
+files:
+ "C:\\scripts\\SSMAssociation.ps1":
+   content: |
+     Import-Module AWSPowerShell
+     $date =get-date
+     if(test-path C:\\transcript.txt) {ri C:\\transcript.txt}
+     Start-transcript -Path C:\\transcript.txt -Force -NoClobber
+     "Date Ran $date"
+     $InstanceId = Invoke-Restmethod -uri http://169.254.169.254/latest/meta-data/instance-id
+     "Instance ID: $InstanceId"
+     $AvailabilityZone = Invoke-RestMethod -uri http://169.254.169.254/latest/meta-data/placement/availability-zone
+     "Availability Zone: $AvailabilityZone"
+     $Region = $AvailabilityZone.Substring(0,$AvailabilityZone.Length-1)
+     "Region: $Region"
+     Set-DefaultAWSRegion $Region
+     "Instance Name: $InstanceName"
+     Rename-Computer -NewName $InstanceId -confirm:$false -force
+     New-SSMAssociation -InstanceId $InstanceId -Name "ssm01" -Region $Region
+     Stop-transcript
+     Restart-Computer -Force
+container_commands:
+  01_SSMAssociation:
+     command: powershell.exe -ExecutionPolicy Bypass -File C:\\scripts\\SSMAssociation.ps1

--- a/configuration-files/aws-provided/instance-configuration/windows-configuration/t2unlimited-instance.config
+++ b/configuration-files/aws-provided/instance-configuration/windows-configuration/t2unlimited-instance.config
@@ -1,0 +1,48 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+#### http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### T2 Unlimited with Elastic Beanstalk for Windows based Environments
+#### Since it is not directly possible to use T2 Unlimited instances with Elastic Beanstalk as of now
+#### the below provided ebextensions config file lets you use T2 instances with Surplus credits.
+###################################################################################################
+
+files:
+  "c:\\windows\\temp\\t2-test.ps1":
+     content : |
+      $instance = (Invoke-WebRequest http://169.254.169.254/latest/meta-data/instance-type).Content
+      if(echo "$instance" | Select-String 't2.*'){ exit 0}else{exit 1}
+
+  "c:\\users\\Administrator\\changecredit.ps1":
+     content: |
+       $az = (Invoke-WebRequest http://169.254.169.254/latest/meta-data/placement/availability-zone).content
+       $region = $az.Substring(0,$az.length-1)
+       $instanceId = (New-Object System.Net.WebClient).DownloadString("http://169.254.169.254/latest/meta-data/instance-id")
+       #Set Default Region
+       Set-DefaultAWSRegion -Region $region
+
+       #Check current credit model
+       Get-EC2CreditSpecification -InstanceId $instanceId
+
+       #Change to unlimit
+       $unlimitedCredit = New-Object -TypeName Amazon.EC2.Model.InstanceCreditSpecificationRequest
+       $unlimitedCredit.InstanceId = $instanceId
+       $unlimitedCredit.CpuCredits = "unlimited"
+       Set-DefaultAWSRegion -Region $region
+       #Get-EC2CreditSpecification -InstanceId $instanceId
+       Edit-EC2InstanceCreditSpecification -InstanceCreditSpecification $unlimitedCredit
+       #Get-EC2CreditSpecification -InstanceId $instanceId
+
+commands:
+  unlimited:
+    command: powershell.exe -ExecutionPolicy Bypass -File C:\\users\\Administrator\\changecredit.ps1

--- a/configuration-files/aws-provided/instance-configuration/windows-configuration/timezone-windows.config
+++ b/configuration-files/aws-provided/instance-configuration/windows-configuration/timezone-windows.config
@@ -1,0 +1,23 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+#### http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file configures the timezone on each instance in the environment.
+#### Its using tzutil command to set timezone on the instance. Have a look
+#### at the URL https://technet.microsoft.com/en-us/library/cc749073%28v=ws.10%29.aspx for all possible
+#### timezone values in this case its done for UTC+1
+###################################################################################################
+
+commands:
+  setting_time_zone:
+    command: tzutil /s "W. Europe Standard Time"

--- a/configuration-files/aws-provided/instance-configuration/windows-configuration/web-http-tracing.config
+++ b/configuration-files/aws-provided/instance-configuration/windows-configuration/web-http-tracing.config
@@ -1,0 +1,32 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+#### http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file enables WindowsFeature Web-Http-Tracing on the windows instance launched
+#### under Elastic Beanstalk and request tracing will capture traces for requests which resulted in
+#### status codes from 400 to 599; by default, the latest 50 error traces will be saved on:
+#### %systemdrive%\inetpub\logs\FailedReqLogFiles\. Request Monitor will enable the feature to
+#### monitor currently/hanging requests.
+###################################################################################################
+
+
+commands:
+  00_install-web-http-tracing:
+    command: "powershell.exe Install-WindowsFeature -Name Web-Http-Tracing"
+    waitAfterCompletion: 0
+  01_enable-web-http-tracing:
+    command: "powershell.exe Enable-WebRequestTracing -StatusCodes 400-599"
+    waitAfterCompletion: 0
+  02_install-web-request-monitoring:
+    command: "powershell.exe Install-WindowsFeature -Name Web-Request-Monitor"
+    waitAfterCompletion: 0

--- a/configuration-files/aws-provided/resource-configuration/README.md
+++ b/configuration-files/aws-provided/resource-configuration/README.md
@@ -1,5 +1,14 @@
+### alb-http-to-https-redirection.config
+This configuration file usage resources to configure HTTP to HTTPS auto redirection at application load balancer (ALB) layer. This will not work with an environment using other load balancer (Classic/Network).
+
 ### autoscaling-cloudwatch-group-metrics.config
 Configures your environment's Auto Scaling Group to send group metrics to Amazon CloudWatch at 1-minute intervals.
+
+### autoscaling-memory-utlization.config
+This configuration file will create custom cloudwatch metrics along with alarms to monitor memory usage of EC2 instances and Trigger auto-scale events based on cloud watch alarms. You can find more information about custom monitoring script here: https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/customize-containers-cw.html#customize-containers-cw-update-roles
+
+### autoscaling-terminate-newest-instance.config
+Terminate newest instance in autoscaling group at the time of scale down event
 
 ### autoscaling-triggers-createnew.config
 Add scaling triggers to your environment's AutoScaling group, in addition to those provisioned by Elastic Beanstalk.

--- a/configuration-files/aws-provided/resource-configuration/alb-http-to-https-redirection.config
+++ b/configuration-files/aws-provided/resource-configuration/alb-http-to-https-redirection.config
@@ -1,0 +1,35 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+####     http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file usage resources to configure HTTP to HTTPS auto redirection at application
+#### load balancer (ALB) layer. This will not work with an environment using other load balancer (Classic/Network)
+###################################################################################################
+
+Resources:
+ AWSEBV2LoadBalancerListener:
+  Type: AWS::ElasticLoadBalancingV2::Listener
+  Properties:
+    LoadBalancerArn:
+      Ref: AWSEBV2LoadBalancer
+    Port: 80
+    Protocol: HTTP
+    DefaultActions:
+      - Type: redirect
+        RedirectConfig:
+          Host: "#{host}"
+          Path: "/#{path}"
+          Port: "443"
+          Protocol: "HTTPS"
+          Query: "#{query}"
+          StatusCode: "HTTP_301"

--- a/configuration-files/aws-provided/resource-configuration/autoscaling-memory-utlization.config
+++ b/configuration-files/aws-provided/resource-configuration/autoscaling-memory-utlization.config
@@ -1,0 +1,82 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+####     http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file will create custom cloudwatch metrics along with alarms to monitor memory
+#### usage of EC2 instances and Trigger auto-scale events based on cloud watch alarms
+#### You can find more infomration about custom monitoring script here:
+#### https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/customize-containers-cw.html#customize-containers-cw-update-roles
+###################################################################################################
+
+packages:
+  yum:
+    perl-DateTime: []
+    perl-Sys-Syslog: []
+    perl-LWP-Protocol-https: []
+    perl-Switch: []
+    perl-URI: []
+    perl-Bundle-LWP: []
+
+sources:
+  /opt/cloudwatch: https://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.1.zip
+
+container_commands:
+  01-setupcron:
+    command: |
+      echo '*/5 * * * * root perl /opt/cloudwatch/aws-scripts-mon/mon-put-instance-data.pl `{"Fn::GetOptionSetting" : { "OptionName" : "CloudWatchMetrics", "DefaultValue" : "--mem-util --disk-space-util --disk-path=/" }}` >> /var/log/cwpump.log 2>&1' > /etc/cron.d/cwpump
+  02-changeperm:
+    command: chmod 644 /etc/cron.d/cwpump
+  03-changeperm:
+    command: chmod u+x /opt/cloudwatch/aws-scripts-mon/mon-put-instance-data.pl
+
+option_settings:
+  "aws:autoscaling:launchconfiguration" :
+    IamInstanceProfile : "aws-elasticbeanstalk-ec2-role"
+  "aws:elasticbeanstalk:customoption" :
+    CloudWatchMetrics : "--mem-util --mem-used --mem-avail --disk-space-util --disk-space-used --disk-space-avail --disk-path=/ --auto-scaling"
+
+
+Resources:
+  MemoryAlarmHigh:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: { "Fn::Join" : ["", [{ "Ref" : "AWSEBEnvironmentName" }, "-Memory-scale-up-alarm." ]]}
+      Namespace: System/Linux
+      Dimensions:
+        - Name: AutoScalingGroupName
+          Value: { "Ref" : "AWSEBAutoScalingGroup" }
+      MetricName: MemoryUtilization
+      Statistic: Average
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 20
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+        - Ref: AWSEBAutoScalingScaleUpPolicy
+
+  MemoryAlarmLow:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: { "Fn::Join" : ["", [{ "Ref" : "AWSEBEnvironmentName" }, "-Memory-scale-down-alarm." ]]}
+      Namespace: System/Linux
+      Dimensions:
+        - Name: AutoScalingGroupName
+          Value: { "Ref" : "AWSEBAutoScalingGroup" }
+      MetricName: MemoryUtilization
+      Statistic: Average
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 5
+      ComparisonOperator: LessThanThreshold
+      AlarmActions:
+        - Ref: AWSEBAutoScalingScaleDownPolicy

--- a/configuration-files/aws-provided/resource-configuration/autoscaling-terminate-newest-instance.config
+++ b/configuration-files/aws-provided/resource-configuration/autoscaling-terminate-newest-instance.config
@@ -1,0 +1,26 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+####     http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file changes the default AutoScaling to terminate new instances first
+#### In case of any scale down event, AutoScaling will teminate the newly lanched instance.
+#### Its useful when your environment is going through frequent scaling acivities and
+#### terminating a good/healthy old instance where as your new instance is not yet ready.
+###################################################################################################
+
+Resources:
+  AWSEBAutoScalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      TerminationPolicies:
+        - NewestInstance

--- a/configuration-files/aws-provided/security-configuration/README.md
+++ b/configuration-files/aws-provided/security-configuration/README.md
@@ -6,11 +6,22 @@ For single instance environments, include `https-singleinstance-securitygroup.co
 ### https-redirect
 Configure the proxy server that runs in front of your application to redirect HTTP requests on port 80 to the same path on HTTPS/443.
 
+### proxy-ratelimit-linux
+Configure Apache or Nginx to rate limit the amount of unique inbound connections per instance in that environment.
+
 ### https-singleinstance-securitygroup.config
 Modify your instance's security group to allow HTTPS traffic on port 443. Use in conjunction with `https-instancecert-<platform>.config` to support HTTPS connections in a single instance environment.
 
-### proxy-ratelimit-linux
-Configure Apache or Nginx to rate limit the amount of unique inbound connections per instance in that environment.
+### loadbalancer-alb-securelistener.config
+The example uses options in the aws:elbv2:listener namespace to configure an HTTPS listener on port 443 with the specified certificate.
+https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/configuring-https-elb.html#configuring-https-elb.configurationfile
+
+### loadbalancer-clb-securelistener.config
+The example uses options in the aws:elb:listener namespace to configure an HTTPS listener on port 443 with the specified certificate.
+https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/configuring-https-elb.html#configuring-https-elb.configurationfile
+
+### loadbalancer-nlb-securelistener.config
+The example uses options in the aws:elbv2:listener namespace to configure a listener on port 443. The listener routes traffic to the default process. https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/configuring-https-elb.html#configuring-https-elb.configurationfile
 
 ### rds-ssl-java.config
 Install SSL certificates for RDS database connections with JDBC.
@@ -26,6 +37,3 @@ Configure the Security Groups for the ELB and the EC2 instances apart of the Aut
 
 ### ssh-sourcerestriction.config
 Use the `SSHSourceRestriction` option in the `aws:autoscaling:launchconfiguration` namespace to restrict SSH traffic to connections from instances in a security group that you control. By default, Elastic Beanstalk opens port 22 to the world when you assign a key pair to your instances. Use this configuration file to override that behavior.
-
-
-

--- a/configuration-files/aws-provided/security-configuration/loadbalancer-alb-securelistener.config
+++ b/configuration-files/aws-provided/security-configuration/loadbalancer-alb-securelistener.config
@@ -1,0 +1,28 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+####     http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### Use this example when your environment has an Application Load Balancer.
+#### The example uses options in the aws:elbv2:listener namespace to configure an HTTPS listener on
+#### port 443 with the specified certificate. The listener routes traffic to the default process.
+
+#### Replace SSLCertificateArns with the ARN of your certificate. The certificate can be one
+#### that you created or uploaded in AWS Certificate Manager (ACM) (preferred), or one that you uploaded to IAM with the AWS CLI.
+#### https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/configuring-https-elb.html#configuring-https-elb.configurationfile
+###################################################################################################
+
+option_settings:
+  aws:elbv2:listener:443:
+    ListenerEnabled: 'true'
+    Protocol: HTTPS
+    SSLCertificateArns: arn:aws:acm:us-east-2:1234567890123:certificate/####################################

--- a/configuration-files/aws-provided/security-configuration/loadbalancer-clb-securelistener.config
+++ b/configuration-files/aws-provided/security-configuration/loadbalancer-clb-securelistener.config
@@ -1,0 +1,29 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+####     http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### Use this example when your environment has a Classic Load Balancer.
+#### The example uses options in the aws:elb:listener namespace to configure an HTTPS listener on
+#### port 443 with the specified certificate, and to forward the decrypted traffic to the instances
+#### in your environment on port 80.
+####
+#### Replace theSSLCertificateId with the ARN of your certificate. The certificate can be one
+#### that you created or uploaded in AWS Certificate Manager (ACM) (preferred), or one that you uploaded to IAM with the AWS CLI.
+#### https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/configuring-https-elb.html#configuring-https-elb.configurationfile
+###################################################################################################
+
+option_settings:
+  aws:elb:listener:443:
+    SSLCertificateId: arn:aws:acm:us-east-2:1234567890123:certificate/####################################
+    ListenerProtocol: HTTPS
+    InstancePort: 80

--- a/configuration-files/aws-provided/security-configuration/loadbalancer-nlb-securelistener.config
+++ b/configuration-files/aws-provided/security-configuration/loadbalancer-nlb-securelistener.config
@@ -1,0 +1,23 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+####     http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### Use this example when your environment has an Network Load Balancer.
+#### The example uses options in the aws:elbv2:listener namespace to configure a listener on
+#### port 443. The listener routes traffic to the default process.
+#### https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/configuring-https-elb.html#configuring-https-elb.configurationfile
+###################################################################################################
+
+option_settings:
+  aws:elbv2:listener:443:
+    ListenerEnabled: 'true'


### PR DESCRIPTION
*Issue #, if available:*
The Amazon Inspector Agent installation command was hanging due to missing /quite switch.
Also, added more checks before granting permission in adding-writepermission-iisfolder.config. . 

*Description of changes:*
Fixed Amazon Inspector Agent installation command, removed symbols and added more conditions before granting permission in adding-writepermission-iisfolder.config. 