### PR TITLE
Update listening of mountpoint -q output

### DIFF
--- a/configuration-files/aws-provided/instance-configuration/storage-efs-mountfilesystem.config
+++ b/configuration-files/aws-provided/instance-configuration/storage-efs-mountfilesystem.config
@@ -83,6 +83,7 @@ files:
         fi
 
         mountpoint -q ${EFS_MOUNT_DIR}
+        echo $?
         if [ $? -ne 0 ]; then
             echo "mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 ${EFS_FILE_SYSTEM_ID}.efs.${EFS_REGION}.amazonaws.com:/ ${EFS_MOUNT_DIR}"
             mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 ${EFS_FILE_SYSTEM_ID}.efs.${EFS_REGION}.amazonaws.com:/ ${EFS_MOUNT_DIR}


### PR DESCRIPTION
The line testing the output of mountpoint doesn't get any feedback from the silent output of mountpoint and makes the Elasticebeanstalk fail.

*Issue #, if available:*

*Description of changes:*
Adds an echo to output the result of mountpoint -q and make the result listenable by the following line

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
