### PR TITLE
Update vpc-private.yaml

### DIFF
--- a/cfn-templates/vpc-private.yaml
+++ b/cfn-templates/vpc-private.yaml
@@ -24,10 +24,7 @@
 #### This template creates the following resources-
 ####   - A VPC with the IP range 172.31.0.0/16
 ####   - 2 private subnets for the EC2 instances that run your application
-####   - 2 public subnets for the load balancer that routes traffic to the instances
-####   - An Internet gateway, NAT gateway, and route table to allow the instances
-####     to communicate with the load balancer and the Internet.
-####
+####  ####
 ###################################################################################################
 
 Resources:


### PR DESCRIPTION
The comments of second paragraph were the same as it in vpc-privatepublic.yaml which is not correct.

*Issue #, if available: The comments 
"####   - 2 public subnets for the load balancer that routes traffic to the instances
####   - An Internet gateway, NAT gateway, and route table to allow the instances
####     to communicate with the load balancer and the Internet."
does not comply with the vpc-private.yaml

*Description of changes: Delete the three lines from the file


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
