### PR TITLE
Added ebextensions script for Apache proxy server to LimitRequestBody

### DIFF
--- a/configuration-files/community-provided/instance-configuration/01-apache-request-limit.config
+++ b/configuration-files/community-provided/instance-configuration/01-apache-request-limit.config
@@ -1,0 +1,21 @@
+###################################################################################################
+#### This configuration file which limits the request body size for an Apache proxy
+####
+#### The workflow will create a *.conf file in the directory which Apache uses to check for
+#### additional proxy configuration which extends the existing Apache proxy configuration.
+####
+#### The value which LimitRequestBody accepts is a number, and represent bytes. In this case the
+#### request body is limited to 102400 bytes.
+####
+#### This will work for Apache proxy servers running on both Amazon Linux and Amazon Linux 2 AMIs
+####
+#### Author: @pedreviljoen
+###################################################################################################
+
+files:
+    "/etc/httpd/conf.d/filelimit.conf":
+        mode: "000755"
+        owner: root
+        group: root
+        content: |
+            LimitRequestBody 102400


### PR DESCRIPTION
*Description of changes:*
Added a ebextension script for limiting the request body size when using Apache as the proxy server. The script will work for both Amazon Linux and Amazon Linux 2 AMIs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
