### PR TITLE
Add ASG Capacity Rebalance ebextension

### DIFF
--- a/configuration-files/aws-provided/resource-configuration/autoscaling-capacity-rebalancing.config
+++ b/configuration-files/aws-provided/resource-configuration/autoscaling-capacity-rebalancing.config
@@ -1,0 +1,33 @@
+###################################################################################################
+#### Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+####     http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file configures your environment's Auto Scaling group to enable 
+#### the Capacity Rebalancing feature. 
+####
+#### If you are using Spot Instances on your environment, using Capacity Rebalancing makes your
+#### Auto Scaling group attempt to replace Spot Instances at elevated risk of interruption before
+#### they are interrupted by Amazon EC2. Capacity Rebalancing complements the capacity-optimized 
+#### allocation strategy (designed to help find the most optimal spare capacity) and the mixed 
+#### instances policy (designed to enhance availability by deploying across multiple instance types
+#### running in multiple Availability Zones). 
+####
+#### Check out the Capacity Rebalancing documentation for further information:
+####      https://docs.aws.amazon.com/autoscaling/ec2/userguide/capacity-rebalance.html
+###################################################################################################
+
+Resources:
+    AWSEBAutoScalingGroup:
+      Type: AWS::AutoScaling::AutoScalingGroup
+      Properties:
+        CapacityRebalance: true


### PR DESCRIPTION
*Description of changes:* This PR adds a sample .ebextension to enable [Capacity Rebalancing](https://docs.aws.amazon.com/autoscaling/ec2/userguide/capacity-rebalance.html) on the environment Auto Scaling group. This is useful for load balanced environments using Spot Instances, as it makes Auto Scaling proactively replace instances at elevated risk of interruption.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
