### PR TITLE
Remove Unnecessary Alarm Configurations and Add Custom Scaling Policy

### DIFF
--- a/configuration-files/aws-provided/environment-configuration/workertier-scaleonqueuesize.config
+++ b/configuration-files/aws-provided/environment-configuration/workertier-scaleonqueuesize.config
@@ -24,15 +24,23 @@
 ###################################################################################################
 
 Resources:
-  AWSEBCloudwatchAlarmHigh:
-    Type: AWS::CloudWatch::Alarm
+  QueueDepthScaleUpPolicy:
+    Type: AWS::AutoScaling::ScalingPolicy
     Properties:
-      AlarmActions: []
-
-  AWSEBCloudwatchAlarmLow:
-    Type: AWS::CloudWatch::Alarm
+      AdjustmentType: "ChangeInCapacity"
+      PolicyType: "SimpleScaling"
+      Cooldown: "300"
+      AutoScalingGroupName: {Ref: AWSEBAutoScalingGroup}
+      ScalingAdjustment: 1
+      
+  QueueDepthScaleDownPolicy:
+    Type: AWS::AutoScaling::ScalingPolicy
     Properties:
-      AlarmActions: []
+      AdjustmentType: "ChangeInCapacity"
+      PolicyType: "SimpleScaling"
+      Cooldown: "300"
+      AutoScalingGroupName: {Ref: AWSEBAutoScalingGroup}
+      ScalingAdjustment: -1
 
   QueueDepthAlarmHigh:
     Type: AWS::CloudWatch::Alarm
@@ -49,7 +57,7 @@ Resources:
       Threshold: 20
       ComparisonOperator: GreaterThanThreshold
       AlarmActions:
-        - Ref: AWSEBAutoScalingScaleUpPolicy
+        - Ref: QueueDepthScaleUpPolicy
 
   QueueDepthAlarmLow:
     Type: AWS::CloudWatch::Alarm
@@ -66,4 +74,4 @@ Resources:
       Threshold: 5
       ComparisonOperator: LessThanThreshold
       AlarmActions:
-        - Ref: AWSEBAutoScalingScaleDownPolicy
+        - Ref: QueueDepthScaleDownPolicy


### PR DESCRIPTION
*Description of changes:*
This template contains unnecessary empty CloudWatch alarms, which cannot be deployed and was confusing customers by causing deployment failures when testing this template. Additionally, this adds a dedicated Scaling Policy to the template, rather than having the alarms rely on the default Elastic Beanstalk Scaling Policies.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
