### PR TITLE
Tag Elastic Beanstalk EBS volumes

### DIFF
--- a/configuration-files/community-provided/instance-configuration/tag-volume.config
+++ b/configuration-files/community-provided/instance-configuration/tag-volume.config
@@ -1,0 +1,17 @@
+###################################################################################################
+#### Tag EBS volume Name with the Elastic Beanstalk environment name. This is the same naming
+#### convention used on the instances to which the volumes are attached. Without this config
+#### Elastic Beanstalk leaves the volume Name tag empty.
+#### This requires that the IAM role have EC2 Create Tag and EC2 Describe permissions since the
+#### volume is tagged by the instance (as opposed to the service/service role).
+####
+#### Note: According to support this is "an ongoing feature request to add support for tagging EBS
+####       volume by allowing the Resource tags to be propagated to the Launch Template".
+####       Which is to say: hopefully this will not be required at some point in future.
+####
+#### Author: @hayd
+###################################################################################################
+
+container_commands:
+  tagVolume:
+    command: aws ec2 create-tags --resources $(aws ec2 describe-instances --region $(curl http://169.254.169.254/latest/meta-data/placement/availability-zone|  sed 's/[a-z]$//') --instance-id $(curl http://169.254.169.254/latest/meta-data/instance-id ) --output text --query Reservations[0].Instances[0].BlockDeviceMappings[0].Ebs.VolumeId) --region $(curl http://169.254.169.254/latest/meta-data/placement/availability-zone|  sed 's/[a-z]$//') --tags Key=Name,Value=$(/opt/elasticbeanstalk/bin/get-config container -k environment_name)


### PR DESCRIPTION
Adds a community provided .config file to tag instance volumes created by Elastic Beanstalk.

Note: This is a slightly amended version of one provided to me by AWS Support (by Arpit C).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
