### PR TITLE
Autoscaling based on memory utilization with CW agent

### DIFF
--- a/configuration-files/aws-provided/resource-configuration/autoscaling-memory-utilization-cwagent.config
+++ b/configuration-files/aws-provided/resource-configuration/autoscaling-memory-utilization-cwagent.config
@@ -1,0 +1,92 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+####     http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file will create custom CloudWatch metrics and alarms to monitor memory
+#### usage of EC2 instances and trigger auto scaling events.
+#### You can find more information about configuring the CloudWatch agent here:
+#### https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/customize-containers-cw.html#customize-containers-cw-update-roles
+###################################################################################################
+
+files:  
+  "/opt/aws/amazon-cloudwatch-agent/bin/config.json": 
+    mode: "000600"
+    owner: root
+    group: root
+    content: |
+      {
+        "agent": {
+          "metrics_collection_interval": 60,
+          "run_as_user": "root"
+        },
+        "metrics": {
+          "append_dimensions": {
+            "AutoScalingGroupName": "${aws:AutoScalingGroupName}"
+          },
+          "metrics_collected": {
+            "mem": {
+              "measurement": [
+                "used_percent"
+              ]
+            }
+          }
+        }
+      }
+
+container_commands:
+  start_cloudwatch_agent: 
+    command: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/bin/config.json
+
+Resources:
+  AWSEBCloudwatchAlarmHigh:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions: []
+  AWSEBCloudwatchAlarmLow:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions: []
+  MemoryAlarmHigh:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: { "Fn::Join" : ["", [{ "Ref" : "AWSEBEnvironmentName" }, "-Memory-scale-up-alarm." ]]}
+      Namespace: CWAgent
+      Dimensions:
+        - Name: AutoScalingGroupName
+          Value: { "Ref" : "AWSEBAutoScalingGroup" }
+      MetricName: mem_used_percent
+      Statistic: Average
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 50
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - Ref: AWSEBAutoScalingScaleUpPolicy
+  MemoryAlarmLow:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: { "Fn::Join" : ["", [{ "Ref" : "AWSEBEnvironmentName" }, "-Memory-scale-down-alarm." ]]}
+      Namespace: CWAgent
+      Dimensions:
+        - Name: AutoScalingGroupName
+          Value: { "Ref" : "AWSEBAutoScalingGroup" }
+      MetricName: mem_used_percent
+      Statistic: Average
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 20
+      ComparisonOperator: LessThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - Ref: AWSEBAutoScalingScaleDownPolicy


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Added sample for configuring autoscaling based on memory utilization using the CloudWatch agent. This is meant to replace the existing memory utilization autoscaling sample that uses deprecated CloudWatch monitoring scripts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
