### PR TITLE
Added configuration for logging Ruby on Rails server logs in CloudWatch

### DIFF
--- a/configuration-files/community-provided/instance-configuration/amazon-linux-2023-ruby-on-rails-cloudwatch.config
+++ b/configuration-files/community-provided/instance-configuration/amazon-linux-2023-ruby-on-rails-cloudwatch.config
@@ -1,0 +1,42 @@
+files:
+  "/tmp/cw-instance-logs.json":
+    content: |
+      {
+        "metrics": {
+          "append_dimensions": {
+            "AutoScalingGroupName": "${aws:AutoScalingGroupName}"
+          },
+          "metrics_collected": {
+            "mem": {
+              "measurement": [
+                "mem_used_percent"
+              ],
+              "metrics_collection_interval": 1
+            }
+          }
+        },
+        "logs": {
+          "logs_collected": {
+            "files": {
+              "collect_list": [
+                {
+                  "file_path": "/var/app/containerfiles/logs/production.log",
+                  "log_group_name": "`{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/log/production"]]}`",
+                  "log_stream_name": "{instance_id}"
+                },
+                {
+                  "file_path": "/var/app/containerfiles/logs/staging.log",
+                  "log_group_name": "`{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/log/staging"]]}`",
+                  "log_stream_name": "{instance_id}"
+                }
+              ]
+            }
+          }
+        }
+      }
+
+container_commands:
+  01-custom-cw-config:
+    command: |
+      echo "Enabling custom CloudWatch configuration"
+      /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a append-config -m ec2 -s -c file:/tmp/cw-instance-logs.json


### PR DESCRIPTION
[*Issue 169*](https://github.com/awsdocs/elastic-beanstalk-samples/issues/169)

*Description of changes:*
Added an updated example to stream logs to CloudWatch from Amazon Linux 2023 using the `amazon-cloudwatch-agent`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
