### PR TITLE
Update cron-leaderonly-linux.config

### DIFF
--- a/configuration-files/aws-provided/instance-configuration/cron-leaderonly-linux.config
+++ b/configuration-files/aws-provided/instance-configuration/cron-leaderonly-linux.config
@@ -75,8 +75,9 @@ files:
     group: root
     content: |
       #!/bin/bash
-      INSTANCE_ID=`curl http://169.254.169.254/latest/meta-data/instance-id 2>/dev/null`
-      REGION=`curl -s http://169.254.169.254/latest/dynamic/instance-identity/document 2>/dev/null | jq -r .region`
+      AWS_TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+      INSTANCE_ID=`curl -H "X-aws-ec2-metadata-token: $AWS_TOKEN" http://169.254.169.254/latest/meta-data/instance-id 2>/dev/null`
+      REGION=`curl -s -H "X-aws-ec2-metadata-token: $AWS_TOKEN" http://169.254.169.254/latest/dynamic/instance-identity/document 2>/dev/null | jq -r .region`
 
       # Find the Auto Scaling Group name from the Elastic Beanstalk environment
       ASG=`aws ec2 describe-tags --filters "Name=resource-id,Values=$INSTANCE_ID" \


### PR DESCRIPTION
fix: use /api/token to obtain metadata INSTANCE_ID and REGION