### PR TITLE
This config file updates the Auto Scaling configuration to use a launch template instead of a launch configuration.

### DIFF
--- a/configuration-files/community-provided/security-configuration/auto-scaling-launch-from-template.config
+++ b/configuration-files/community-provided/security-configuration/auto-scaling-launch-from-template.config
@@ -1,0 +1,40 @@
+###################################################################################################
+####
+#### "EC2 Auto Scaling Launch Configuration Deprecation Notification"
+#### This config file will address this issue.
+#### This config file updates the Auto Scaling configuration to use a launch template instead of a launch configuration.
+#### When the eb create command is executed, the new launch template settings ensure that instances are configured correctly. 
+#### This also includes disabling IMDSv1 for enhanced security.
+####
+###################################################################################################
+
+###################################################################################################
+####
+#### Usage
+#### The following properties can be changed:
+#### myAppName: Specify the application name. Example: My App
+#### Description: Provide a brief description of the change. Example: Set up launch settings for my app
+#### Value: Set the maximum and minimum values for the EC2 instance count.
+#### SolutionStackName: Specify the stack name to use. Example: 64bit Amazon Linux 2023 v4.3.0 running PHP 8.3
+#### To find the exact solution stacks, you can use the following AWS CLI command: 'aws elasticbeanstalk list-available-solution-stacks'.
+#### 
+###################################################################################################
+
+Resources:
+  sampleConfigurationTemplate:
+    Type: AWS::ElasticBeanstalk::ConfigurationTemplate
+    Properties:
+      ApplicationName: myAppName
+      Description: AWS ElasticBeanstalk Sample Configuration Template
+      OptionSettings:
+        - Namespace: aws:autoscaling:asg
+          OptionName: MinSize
+          Value: '1'
+        - Namespace: aws:autoscaling:asg
+          OptionName: MaxSize
+          Value: '2'
+      SolutionStackName: Your stack name
+
+option_settings:
+  aws:autoscaling:launchconfiguration:
+    DisableIMDSv1: true


### PR DESCRIPTION
This configuration file addresses the issue described in the 'EC2 Auto Scaling Launch Configuration Deprecation Notification'.