### PR TITLE
Update CloudWatch custom logs ebextensions to use CloudWatch agent

### DIFF
--- a/configuration-files/aws-provided/instance-configuration/logs-streamtocloudwatch-linux.config
+++ b/configuration-files/aws-provided/instance-configuration/logs-streamtocloudwatch-linux.config
@@ -12,65 +12,50 @@
 ###################################################################################################
 
 ###################################################################################################
-#### The following file installs and configures the AWS CloudWatch Logs agent to push logs to a Log
-#### Group in CloudWatch Logs.
+#### The following file configures the AWS CloudWatch agent to push logs to a Log Group in CloudWatch Logs.
 #### 
-#### The configuration below sets the logs to be pushed, the Log Group name to push the logs to and
-#### the Log Stream name as the instance id. The following files are examples of logs that will be
-#### streamed to CloudWatch Logs in near real time:
-#### 
-#### /var/log/messages
-#### /var/log/dmesg
-#### 
+#### The configuration below sets the logs to be pushed, the Log Group name to push the logs to,
+#### the Log Stream name as the instance id, and the log retention period.
+#### This example streams /var/log/messages, but you can modify it stream other files.
+#### `retention_in_days` is optional.
+####
+#### Find more information about configuring the CloudWatch agent here:
+#### https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html
+####
 #### You can then access the CloudWatch Logs by accessing the AWS CloudWatch Console and clicking
 #### the "Logs" link on the left. The Log Group name will follow this format:
 ####
 #### /aws/elasticbeanstalk/<environment name>/<full log name path>
 ####
-#### Please note this configuration can be used additionally to the "Log Streaming" feature:
+#### Please note this configuration should be used additionally to the "Log Streaming" feature:
 #### http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.cloudwatchlogs.html
 ###################################################################################################
 
-packages:
-  yum:
-    awslogs: []
-
 files:
-  "/etc/awslogs/awscli.conf" :
-    mode: "000600"
+  "/opt/aws/amazon-cloudwatch-agent/etc/my_log_config.json":
+    mode: "0644"
     owner: root
     group: root
     content: |
-      [plugins]
-      cwlogs = cwlogs
-      [default]
-      region = `{"Ref":"AWS::Region"}`
-
-  "/etc/awslogs/awslogs.conf" :
-    mode: "000600"
-    owner: root
-    group: root
-    content: |
-      [general]
-      state_file = /var/lib/awslogs/agent-state
-
-  "/etc/awslogs/config/logs.conf" :
-    mode: "000600"
-    owner: root
-    group: root
-    content: |
-      [/var/log/messages]
-      log_group_name = `{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/log/messages"]]}`
-      log_stream_name = {instance_id}
-      file = /var/log/messages
-
-      [/var/log/dmesg]
-      log_group_name = `{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/log/dmesg"]]}`
-      log_stream_name = {instance_id}
-      file = /var/log/dmesg
-
-commands:
-  "01":
-    command: systemctl enable awslogsd.service
-  "02":
-    command: systemctl restart awslogsd
+      {
+        "logs": {
+          "logs_collected": {
+            "files": {
+              "collect_list": [
+                {
+                  "file_path": "/var/log/messages",
+                  "log_group_name": "`{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/log/messages"]]}`",
+                  "log_stream_name": "{instance_id}",
+                  "retention_in_days": 7
+                }
+              ]
+            }
+          }
+        }
+      }
+container_commands:
+  01_append_cloudwatch_agent_config:
+    command: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a append-config -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/my_log_config.json
+  02_remove_backup_file:
+    command: rm -f /opt/aws/amazon-cloudwatch-agent/etc/my_log_config.json.bak
+    ignoreErrors: true


### PR DESCRIPTION
Related issue: https://github.com/aws/elastic-beanstalk-roadmap/issues/313

*Description of changes:*
- Update CloudWatch custom logs ebextensions to use CloudWatch agent instead of deprecated CloudWatch Logs agent. This version should work on AL2 and AL2023 platforms.
- Update the comments to reflect the update.
- Remove package installation because `amazon-cloudwatch-agent` should be installed by default.
- Link to the appropriate CloudWatch documentation.
- Change "can" to "should" be used additionally to the "Log Streaming" feature. To use without enabling log streaming, I expect there might need to be modifications to this sample, such as using `fetch-config` instead of `append-config`.
- Remove `/var/log/dmesg` from the example because this file is not there by default on AL2023.
- Add example of configuring retention period.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
