### PR TITLE
add config file to modify rate limiting of logs

### DIFF
--- a/configuration-files/aws-provided/instance-configuration/logs-ratelimitcloudwatchlogs-linux.config
+++ b/configuration-files/aws-provided/instance-configuration/logs-ratelimitcloudwatchlogs-linux.config
@@ -1,0 +1,57 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+####     http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file modifies the default rate limiting provided by Amazon Linux to increase 
+#### frequency of logging on EB instances.
+####
+#### Logging rate limits on Elastic Beanstalk instances are modified by:
+#### 1. Creating custom config files for journald and rsyslog with increased rate limits
+#### 2. Moving these files to their respective .d directories (/etc/systemd/journald.conf.d/ and /etc/rsyslog.d/)
+#### 3. Restarting both logging services to apply the changes
+####
+#### Note: Complete disabling of rate limiting is NOT RECOMMENDED as it could lead to excessive
+#### disk usage or system performance issues during unexpected log bursts.
+###################################################################################################
+
+files:
+    /tmp/custom_journald.conf:
+        mode: "000644"
+        owner: root
+        group: root
+        content: |
+            [Journal]
+            RateLimitIntervalSec=600
+            RateLimitBurst=100000
+
+    /tmp/custom_rsyslog.conf:
+        mode: "000644"
+        owner: root
+        group: root
+        content: |
+            $SystemLogRateLimitInterval 600
+            $SystemLogRateLimitBurst    100000
+            $imjournalRateLimitInterval 600
+            $imjournalRatelimitBurst    1000000
+
+commands:
+    01_mv_custom_rsyslog.conf:
+        command: mv /tmp/custom_rsyslog.conf /etc/rsyslog.d/
+    02_create_journald.conf.d_dir:
+        command: cd /etc/systemd && mkdir journald.conf.d
+    03_mv_custom_journald.conf:
+        command: mv /tmp/custom_journald.conf /etc/systemd/journald.conf.d
+    04_restart_journald:
+        command: systemctl restart systemd-journald
+    05_restart_rsyslog:
+        command: systemctl restart rsyslog


### PR DESCRIPTION
*Description of changes:*
- Added a .ebextension file that allows the user to change the default rate limiting parameters provided by Elastic Beanstalk
- Increase the rate limit interval to 600 seconds and adjust burst limits to handle higher log volumes 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
