### PR TITLE
Add config file for scheduling restarts on Windows during deployment

### DIFF
--- a/configuration-files/aws-provided/instance-configuration/windows-configuration/scheduled-restart.config
+++ b/configuration-files/aws-provided/instance-configuration/windows-configuration/scheduled-restart.config
@@ -1,0 +1,45 @@
+###################################################################################################
+#### Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+#### http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###
+# This is an example ebextension for using scheduled tasks 
+# to ensure a computer restart occurs late during first boot, 
+# such as to apply a computer rename or domain join. 
+# This avoids restarting too early and interrupting 
+# the first time Elastic Beanstalk bootstrapping.
+#
+# Note this example is provided as-is, and it is up to 
+# the customer to test and modify on their own to fit 
+# their needs before trying in production.
+###
+
+files:
+  "C:\\Program Files\\Amazon\\ElasticBeanstalk\\hooks\\appdeploy\\post\\9999999_reboot_workaround.ps1":
+    content: |
+      Function Reboot-Computer {
+                 Unregister-ScheduledTask -TaskName systemReboot -Confirm:$false 
+                 $action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument 'Restart-Computer -Force'
+                 $trigger = New-JobTrigger -At (get-date).AddMinutes(5) -Once
+                 $principal = New-ScheduledTaskPrincipal -UserId SYSTEM -LogonType ServiceAccount -RunLevel Highest
+                 $definition = New-ScheduledTask -Action $action -Principal $principal -Trigger $trigger -Description "Run systemReboot at startup"
+                 Register-ScheduledTask -TaskName systemReboot -InputObject $definition
+      }
+
+      #Example computer rename
+      Rename-Computer -NewName eb-new-name
+      Reboot-Computer
+      
+commands:
+  01_remove_bak_files:
+    command: "del /F \"C:\\Program Files\\Amazon\\ElasticBeanstalk\\hooks\\appdeploy\\post\\*.bak\""
+    ignoreErrors: true


### PR DESCRIPTION
*Description of changes:*
- Added a .ebextension file that allows the user to schedule restarts on Elastic Beanstalk Windows environments


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
